### PR TITLE
Fix Fish shell variable scope in init command

### DIFF
--- a/try.rb
+++ b/try.rb
@@ -897,12 +897,13 @@ if __FILE__ == $0
     fish_script = <<~SHELL
       function try
         set -l script_path "#{script_path}"
+        set -l cmd ""
         # Check if first argument is a known command
         switch $argv[1]
           case clone worktree init
-            set -l cmd (/usr/bin/env ruby "$script_path"#{path_arg} $argv 2>/dev/tty | string collect)
+            set cmd (/usr/bin/env ruby "$script_path"#{path_arg} $argv 2>/dev/tty | string collect)
           case '*'
-            set -l cmd (/usr/bin/env ruby "$script_path" cd#{path_arg} $argv 2>/dev/tty | string collect)
+            set cmd (/usr/bin/env ruby "$script_path" cd#{path_arg} $argv 2>/dev/tty | string collect)
         end
         set -l rc $status
         if test $rc -eq 0


### PR DESCRIPTION
## Summary

Fixes a Fish shell variable scope bug where the `cd` command was not being executed after selecting a directory.

## Problem

In Fish shell, variables declared with `set -l` inside `switch` case blocks are scoped to that block only. This caused the `cmd` variable to be undefined outside the switch statement, resulting in the cd command not being executed.

## Solution

- Declare `cmd` variable before the switch statement with `set -l cmd ""`
- Use `set` (without `-l`) inside case blocks to update the outer scope variable

## Testing

All existing tests pass after this fix (22 tests, 68 assertions).